### PR TITLE
Show battery % in split

### DIFF
--- a/clock.c
+++ b/clock.c
@@ -134,11 +134,17 @@ void draw_digital_clock(Canvas* canvas, ClockConfig* cfg, DateTime* dt, uint16_t
         char* pm = hour >= 12 ? "PM" : "AM";
         hour = hour % 12 == 0 ? 12 : hour % 12;
         canvas_set_font(canvas, FontSecondary);
-        canvas_draw_str_aligned(canvas, cfg->ofs_x, OFS_Y - 10, AlignCenter, AlignBottom, pm);
+        canvas_draw_str_aligned(canvas, cfg->ofs_x, OFS_Y + 10, AlignCenter, AlignTop, pm);
     }
     snprintf(buf, 6, "%2u:%02u", hour % 24, dt->minute % 60);
     canvas_set_font(canvas, FontBigNumbers);
     canvas_draw_str_aligned(canvas, cfg->ofs_x, OFS_Y, AlignCenter, AlignCenter, buf);
+    
+    static char batt_buf[5];
+    snprintf(batt_buf, 5, "%u%%", cfg->battery_pct);
+    canvas_set_font(canvas, FontSecondary);
+    canvas_draw_str_aligned(canvas, cfg->ofs_x, OFS_Y - 10, AlignCenter, AlignBottom, batt_buf);
+    
     if(cfg->face_type == DigitalRectangular) {
         for(uint8_t i = 0; i < 45; i++)
             draw_line(canvas, cfg->ofs_x, &cfg->face.minutes[(dt->second - i + 60) % 60], Normal);
@@ -235,6 +241,7 @@ void init_clock_config(ClockConfig* cfg) {
     cfg->digits_mod = 3;
     cfg->face_type = Rectangular;
     cfg->ofs_x = OFS_MID_X;
+    cfg->battery_pct = 0;
 }
 
 void modify_clock_up(ClockConfig* cfg) {

--- a/clock.c
+++ b/clock.c
@@ -207,7 +207,7 @@ int get_weekday(int year, int month, int day) {
     return (day + 13 * (month + 1) / 5 + K + K / 4 + J / 4 + 5 * J) % 7;
 }
 
-void draw_date(Canvas* canvas, DateTime* dt) {
+void draw_date(Canvas* canvas, DateTime* dt, ClockConfig* cfg) {
     static char day[3];
     snprintf(day, 3, "%2u", dt->day % 32);
     const char* month = MONTHS[(dt->month - 1) % 12];
@@ -217,6 +217,14 @@ void draw_date(Canvas* canvas, DateTime* dt) {
     Align m_align = AlignRight;
     if(locale_get_date_format() == LocaleDateFormatDMY)
         ofs_x = -2, d_align = AlignRight, m_align = AlignLeft;
+    
+    if(cfg->face_type != DigitalRectangular && cfg->face_type != DigitalRound) {
+        static char batt_buf[5];
+        snprintf(batt_buf, 5, "%u%%", cfg->battery_pct);
+        canvas_set_font(canvas, FontSecondary);
+        canvas_draw_str_aligned(canvas, OFS_RIGHT_X, OFS_Y - 10, AlignCenter, AlignBottom, batt_buf);
+    }
+    
     canvas_set_font(canvas, FontBigNumbers);
     canvas_draw_str_aligned(canvas, OFS_RIGHT_X + ofs_x, OFS_Y, d_align, AlignCenter, day);
     canvas_set_font(canvas, FontPrimary);
@@ -231,7 +239,7 @@ void draw_clock(Canvas* canvas, ClockConfig* cfg, DateTime* dt, uint16_t ms) {
         draw_digital_clock(canvas, cfg, dt, ms);
     else
         draw_analog_clock(canvas, cfg, dt, ms);
-    if(cfg->split) draw_date(canvas, dt);
+    if(cfg->split) draw_date(canvas, dt, cfg);
 }
 
 void init_clock_config(ClockConfig* cfg) {

--- a/clock.h
+++ b/clock.h
@@ -37,7 +37,7 @@ typedef struct {
     FaceType face_type;
     uint8_t ofs_x;
     ClockFace face;
-    uint8_t battery_pct;
+    bool show_battery;
 } ClockConfig;
 
 void calc_clock_face(ClockConfig* cfg);

--- a/clock.h
+++ b/clock.h
@@ -37,6 +37,7 @@ typedef struct {
     FaceType face_type;
     uint8_t ofs_x;
     ClockFace face;
+    uint8_t battery_pct;
 } ClockConfig;
 
 void calc_clock_face(ClockConfig* cfg);

--- a/flipperzero-clock.c
+++ b/flipperzero-clock.c
@@ -30,6 +30,8 @@ static void app_draw_callback(Canvas* canvas, void* ctx) {
     furi_hal_rtc_get_datetime(&dt);
     if(dt.second != app->second) app->ms_adjust = tick % 1000;
     app->second = dt.second;
+    app->cfg.battery_pct = furi_hal_power_get_pct();
+    
     draw_clock(canvas, &app->cfg, &dt, (tick - app->ms_adjust) % 1000);
     furi_mutex_release(app->mutex);
 }

--- a/flipperzero-clock.c
+++ b/flipperzero-clock.c
@@ -30,7 +30,6 @@ static void app_draw_callback(Canvas* canvas, void* ctx) {
     furi_hal_rtc_get_datetime(&dt);
     if(dt.second != app->second) app->ms_adjust = tick % 1000;
     app->second = dt.second;
-    app->cfg.battery_pct = furi_hal_power_get_pct();
     
     draw_clock(canvas, &app->cfg, &dt, (tick - app->ms_adjust) % 1000);
     furi_mutex_release(app->mutex);


### PR DESCRIPTION
Adds battery percentage above the time and moves the AM/PM below (digital only)

#### Before

![2](https://github.com/user-attachments/assets/9e06dc3c-210d-474d-8bcd-d7dc81fe36f0)

![4](https://github.com/user-attachments/assets/a46a535c-1a4e-4064-a623-0d04d569f679)

#### After

![1](https://github.com/user-attachments/assets/b7db2d8a-2c20-45cf-98ed-b22018ca764d)

![3](https://github.com/user-attachments/assets/9fc7a52a-9bc0-4665-9bec-aa16af32e1b5)

